### PR TITLE
Update PersistentDisk after disk attach

### DIFF
--- a/src/bosh-director/lib/bosh/director/deployment_plan/steps/attach_disk_step.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/steps/attach_disk_step.rb
@@ -14,8 +14,9 @@ module Bosh::Director
           cloud_factory = CloudFactory.create_with_latest_configs
           cloud = cloud_factory.get(@disk.cpi)
           @logger.info("Attaching disk #{@disk.disk_cid}")
-          cloud.attach_disk(@disk.instance.vm_cid, @disk.disk_cid)
+          disk_properties = cloud.attach_disk(@disk.instance.vm_cid, @disk.disk_cid)
           MetadataUpdater.build.update_disk_metadata(cloud, @disk, @tags)
+          disk_properties
         end
       end
     end

--- a/src/bosh-director/lib/bosh/director/disk_manager.rb
+++ b/src/bosh-director/lib/bosh/director/disk_manager.rb
@@ -63,8 +63,9 @@ module Bosh::Director
     end
 
     def attach_disk(disk, tags)
-      DeploymentPlan::Steps::AttachDiskStep.new(disk, tags).perform(step_report)
+      disk_properties = DeploymentPlan::Steps::AttachDiskStep.new(disk, tags).perform(step_report)
       mount_disk(disk) if disk.managed?
+      disk_properties
     end
 
     def detach_disk(disk)

--- a/src/bosh-director/lib/bosh/director/jobs/attach_disk.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/attach_disk.rb
@@ -75,7 +75,11 @@ module Bosh::Director
         end
 
         if instance.state == 'stopped'
-          @disk_manager.attach_disk(disk, instance.deployment.tags)
+          disk_properties = @disk_manager.attach_disk(disk, instance.deployment.tags)
+          if disk_properties
+            disk.update(size: disk_properties['size']) if disk_properties['size']
+            disk.update(cloud_properties: disk_properties['cloud_properties']) if disk_properties['cloud_properties']
+          end
         end
       end
     end

--- a/src/bosh-director/lib/cloud/dummy.rb
+++ b/src/bosh-director/lib/cloud/dummy.rb
@@ -182,6 +182,10 @@ module Bosh
         settings = read_agent_settings(agent_id)
         settings['disks']['persistent'][disk_id] = 'attached'
         write_agent_settings(agent_id, settings)
+        {
+            'size' => SecureRandom.random_number(1000),
+            'cloud_properties' => {}
+        }
       end
 
       DETACH_DISK_SCHEMA = Membrane::SchemaParser.parse { {vm_cid: String, disk_id: String} }


### PR DESCRIPTION
Set PersistentDisk with the actual size of the disk attached.
Also update the cloud properties as reported by the cpi.
This prevents unnecessary copy of disk after a disk attach.